### PR TITLE
Only write spectra if spectra.in exists

### DIFF
--- a/src/flow_solver/param.F90
+++ b/src/flow_solver/param.F90
@@ -97,7 +97,7 @@ module param
     logical :: multires=.false.
     logical :: phasefield=.false.
     logical :: salinity=.false.
-    logical :: writespec=.false.
+    logical :: specwrite=.false.
 
     integer :: lvlhalo=2
 

--- a/src/main.F90
+++ b/src/main.F90
@@ -93,8 +93,8 @@ program AFiD
 
     call WriteGridInfo
 
-    inquire(file=trim("spectra.in"),exist=writespec)
-    if (writespec) call InitPowerSpec
+    inquire(file=trim("spectra.in"),exist=specwrite)
+    if (specwrite) call InitPowerSpec
 
 !m===================================
 !m===================================
@@ -179,7 +179,7 @@ program AFiD
     end if
 
     call CalcMeanProfiles
-    if (writespec) call WritePowerSpec
+    if (specwrite) call WritePowerSpec
     if(ismaster)  write(6,*) 'Write plane slices'
     call Mkmov_xcut
     call Mkmov_ycut
@@ -258,7 +258,7 @@ program AFiD
                 write(6,'(a,E11.4,a,i9,a,E11.4)') '  T = ',time,' NTIME = ',ntime,' DT = ',dt
             endif
             call CalcMeanProfiles
-            if (writespec) then
+            if (specwrite) then
                 if (ismaster) write(*,*) "Writing power spectra"
                 call WritePowerSpec
                 if (ismaster) write(*,*) "Done writing power spectra"


### PR DESCRIPTION
Allow runs without the file spectra.in being present by not writing out the power spectra